### PR TITLE
Branch default

### DIFF
--- a/lib/branch_environment.coffee
+++ b/lib/branch_environment.coffee
@@ -1,16 +1,17 @@
-module.exports =
+module.exports = (robot) ->
+  brain = robot.brain
+
   # Public: A class for determining what branch should be deployed
   # for the given environment.
   class BranchEnvironment
-    constructor: (@repo, @environment, @options = {}) ->
-      @brain = @options.brain
+    constructor: (@repo, @environment) ->
       @key   = "branch:#{@repo.nwo}:#{@environment}"
 
     # Public: Get the branch that should be deployed for the environment.
     #
     # Returns String.
     get: ->
-      @brain.get(@key) || @default()
+      brain.get(@key) || @default()
 
     # Public: Set the branch that should be deployed for the environment.
     #
@@ -18,7 +19,7 @@ module.exports =
     #
     # Returns nothing.
     set: (branch) ->
-      @brain.set(@key, branch)
+      brain.set(@key, branch)
 
     # Internal: The default branch mapping.
     # 

--- a/lib/branch_environment.coffee
+++ b/lib/branch_environment.coffee
@@ -1,0 +1,30 @@
+module.exports =
+  # Public: A class for determining what branch should be deployed
+  # for the given environment.
+  class BranchEnvironment
+    constructor: (@repo, @environment, @options = {}) ->
+      @brain = @options.brain
+      @key   = "branch:#{@repo.nwo}:#{@environment}"
+
+    # Public: Get the branch that should be deployed for the environment.
+    #
+    # Returns String.
+    get: ->
+      @brain.get(@key) || @default()
+
+    # Public: Set the branch that should be deployed for the environment.
+    #
+    # branch - String branch name.
+    #
+    # Returns nothing.
+    set: (branch) ->
+      @brain.set(@key, branch)
+
+    # Internal: The default branch mapping.
+    # 
+    # Returns String.
+    default: ->
+      switch @environment
+        when 'staging' then 'develop'
+        else 'master'
+

--- a/lib/deploy.coffee
+++ b/lib/deploy.coffee
@@ -29,7 +29,7 @@ module.exports = (robot) ->
       @environment = @options.environment || 'production'
       @force       = @options.force || false
 
-      @branch or= if @environment == 'staging' then 'develop' else 'master'
+      @branch or= @repo.branch @environment, robot.brain
 
       @config = ENVIRONMENT: @environment
       @config.FORCE = '1' if @force

--- a/lib/deploy.coffee
+++ b/lib/deploy.coffee
@@ -1,6 +1,5 @@
-RepoBranch = require './repo_branch'
-
 module.exports = (robot) ->
+  RepoBranch = require('./repo_branch')(robot)
 
   # Public: Service object for running a deploy.
   #
@@ -29,7 +28,7 @@ module.exports = (robot) ->
       @environment = @options.environment || 'production'
       @force       = @options.force || false
 
-      @branch or= @repo.branch @environment, robot.brain
+      @branch or= @repo.branch @environment
 
       @config = ENVIRONMENT: @environment
       @config.FORCE = '1' if @force

--- a/lib/repo.coffee
+++ b/lib/repo.coffee
@@ -1,18 +1,4 @@
-class BranchEnvironment
-  constructor: (@repo, @environment, @options = {}) ->
-    @brain = @options.brain
-    @key   = "branch:#{@repo.nwo}:#{@environment}"
-
-  get: ->
-    @brain.get(@key) || @default()
-
-  set: (branch) ->
-    @brain.set(@key, branch)
-
-  default: ->
-    switch @environment
-      when 'staging' then 'develop'
-      else 'master'
+BranchEnvironment = require './branch_environment'
 
 module.exports =
   class Repo

--- a/lib/repo.coffee
+++ b/lib/repo.coffee
@@ -4,12 +4,15 @@ class BranchEnvironment
     @key   = "branch:#{@repo.nwo}:#{@environment}"
 
   get: ->
-    switch @environment
-      when 'staging' then 'develop'
-      else 'master'
+    @brain.get(@key) || @default()
 
   set: (branch) ->
     @brain.set(@key, branch)
+
+  default: ->
+    switch @environment
+      when 'staging' then 'develop'
+      else 'master'
 
 module.exports =
   class Repo

--- a/lib/repo.coffee
+++ b/lib/repo.coffee
@@ -1,6 +1,6 @@
-BranchEnvironment = require './branch_environment'
+module.exports = (robot) ->
+  BranchEnvironment = require('./branch_environment')(robot)
 
-module.exports =
   class Repo
     @organization: process.env.SHIPR_GITHUB_ORG
 
@@ -11,15 +11,13 @@ module.exports =
     # Public: Gets the branch that should be deployed for the environment.
     #
     # environment - String environment where the repo will be deployed to.
-    # brain       - A Hubot brain.
     #
     # Returns String.
-    branch: (environment, brain) ->
-      new BranchEnvironment(this, environment, brain: brain).get()
+    branch: (environment) ->
+      new BranchEnvironment(this, environment).get()
 
     # Public: Set the branch that should be deployed for the environment.
     #
     # environment - A String environment where the repo will be deployed to.
-    # brain       - A Hubot brain.
-    setBranch: (environment, branch, brain) ->
-      new BranchEnvironment(this, environment, brain: brain).set(branch)
+    setBranch: (environment, branch) ->
+      new BranchEnvironment(this, environment).set(branch)

--- a/lib/repo.coffee
+++ b/lib/repo.coffee
@@ -1,3 +1,16 @@
+class BranchEnvironment
+  constructor: (@repo, @environment, @options = {}) ->
+    @brain = @options.brain
+    @key   = "branch:#{@repo.nwo}:#{@environment}"
+
+  get: ->
+    switch @environment
+      when 'staging' then 'develop'
+      else 'master'
+
+  set: (branch) ->
+    @brain.set(@key, branch)
+
 module.exports =
   class Repo
     @organization: process.env.SHIPR_GITHUB_ORG
@@ -5,3 +18,19 @@ module.exports =
     constructor: (@name) ->
       @nwo = "#{@constructor.organization}/#{@name}"
       @git = "git@github.com:#{@nwo}.git"
+
+    # Public: Gets the branch that should be deployed for the environment.
+    #
+    # environment - String environment where the repo will be deployed to.
+    # brain       - A Hubot brain.
+    #
+    # Returns String.
+    branch: (environment, brain) ->
+      new BranchEnvironment(this, environment, brain: brain).get()
+
+    # Public: Set the branch that should be deployed for the environment.
+    #
+    # environment - A String environment where the repo will be deployed to.
+    # brain       - A Hubot brain.
+    setBranch: (environment, branch, brain) ->
+      new BranchEnvironment(this, environment, brain: brain).set(branch)

--- a/lib/repo.coffee
+++ b/lib/repo.coffee
@@ -1,0 +1,7 @@
+module.exports =
+  class Repo
+    @organization: process.env.SHIPR_GITHUB_ORG
+
+    constructor: (@name) ->
+      @nwo = "#{@constructor.organization}/#{@name}"
+      @git = "git@github.com:#{@nwo}.git"

--- a/lib/repo_branch.coffee
+++ b/lib/repo_branch.coffee
@@ -1,0 +1,32 @@
+Repo = require './repo'
+
+module.exports =
+  # Public: A value object for splitting a repo#branch combination.
+  #
+  # Examples
+  #
+  #   repoBranch = RepoBranch.parse('r101-api#master')
+  #
+  #   repoBranch.name
+  #   # => r101-api
+  #   
+  #   repoBranch.branch
+  #   # => master
+  #
+  #   repoBranch.repo
+  #   # => Repo
+  class RepoBranch
+
+    # Public: Delimiter that separates the repo from the branch.
+    @delimiter: '#'
+
+    # Public: Takes a string in the format:
+    #
+    # Returns a RepoBranch instance.
+    @parse: (string) ->
+      components = string.split(@delimiter)
+
+      new RepoBranch(components[0], components[1])
+
+    constructor: (@name, @branch) ->
+      @repo = new Repo(@name)

--- a/lib/repo_branch.coffee
+++ b/lib/repo_branch.coffee
@@ -1,6 +1,6 @@
-Repo = require './repo'
+module.exports = (robot) ->
+  Repo = require('./repo')(robot)
 
-module.exports =
   # Public: A value object for splitting a repo#branch combination.
   #
   # Examples

--- a/scripts/shipr.coffee
+++ b/scripts/shipr.coffee
@@ -42,6 +42,6 @@ module.exports = (robot) ->
     name        = msg.match[3]
     repo        = new Repo(name)
 
-    repo.setBranch environment, branch, robot.brain
+    repo.setBranch environment, branch
 
     msg.reply "Ok, the default branch for #{name} when deployed to #{environment} is #{branch}"

--- a/scripts/shipr.coffee
+++ b/scripts/shipr.coffee
@@ -17,7 +17,7 @@
 
 module.exports = (robot) ->
   Deploy = require('../lib/deploy')(robot)
-  Repo   = require('../lib/repo')
+  Repo   = require('../lib/repo')(robot)
 
   deploy = (msg, name, options = {}) ->
     d = new Deploy(name, options).deploy (err, res, body) ->

--- a/scripts/shipr.coffee
+++ b/scripts/shipr.coffee
@@ -10,26 +10,38 @@
 #   hubot deploy <app> to <environment> - Deploy <app> to the <environment>
 #   hubot deploy <app>! - Force deploy <app>
 #   hubot deploy <app> to <environment>! - Force deploy <app> to the <environment>
+#   hubot <branch> is the <environment> branch for <app> - Set the branch that will be deployed when the <environment> is provided
 #
 # Author:
 #   ejholmes
 
 module.exports = (robot) ->
   Deploy = require('../lib/deploy')(robot)
+  Repo   = require('../lib/repo')
 
-  perform = (msg, name, options = {}) ->
-    deploy = new Deploy(name, options).deploy (err, res, body) ->
-      msg.reply "Deploying #{deploy.name} to #{deploy.environment}: #{Deploy.base}/deploys/#{body.id}"
+  deploy = (msg, name, options = {}) ->
+    d = new Deploy(name, options).deploy (err, res, body) ->
+      msg.reply "Deploying #{d.name} to #{d.environment}: #{Deploy.base}/deploys/#{body.id}"
 
   robot.respond /deploy (\S+?)(!)?$/, (msg) ->
     name  = msg.match[1]
     force = msg.match[2]
 
-    perform msg, name, force: force
+    deploy msg, name, force: force
 
   robot.respond /deploy (\S+?) to (\S+?)(!)?$/, (msg) ->
     name        = msg.match[1]
     environment = msg.match[2]
     force       = msg.match[3]
     
-    perform msg, name, environment: environment, force: force
+    deploy msg, name, environment: environment, force: force
+
+  robot.respond /(\S+?) is the (\S+?) branch for (\S+)/, (msg) ->
+    branch      = msg.match[1]
+    environment = msg.match[2]
+    name        = msg.match[3]
+    repo        = new Repo(name)
+
+    console.log robot.brain
+
+    msg.reply "foo"

--- a/scripts/shipr.coffee
+++ b/scripts/shipr.coffee
@@ -10,7 +10,7 @@
 #   hubot deploy <app> to <environment> - Deploy <app> to the <environment>
 #   hubot deploy <app>! - Force deploy <app>
 #   hubot deploy <app> to <environment>! - Force deploy <app> to the <environment>
-#   hubot <branch> is the <environment> branch for <app> - Set the branch that will be deployed when the <environment> is provided
+#   hubot <branch> is the default <environment> branch for <app> - Set the branch that will be deployed when the <environment> is provided
 #
 # Author:
 #   ejholmes

--- a/scripts/shipr.coffee
+++ b/scripts/shipr.coffee
@@ -36,12 +36,12 @@ module.exports = (robot) ->
     
     deploy msg, name, environment: environment, force: force
 
-  robot.respond /(\S+?) is the (\S+?) branch for (\S+)/, (msg) ->
+  robot.respond /(\S+?) is the default (\S+?) branch for (\S+)/, (msg) ->
     branch      = msg.match[1]
     environment = msg.match[2]
     name        = msg.match[3]
     repo        = new Repo(name)
 
-    console.log robot.brain
+    repo.setBranch environment, branch, robot.brain
 
-    msg.reply "foo"
+    msg.reply "Ok, the default branch for #{name} when deployed to #{environment} is #{branch}"

--- a/test/shipr_test.coffee
+++ b/test/shipr_test.coffee
@@ -91,6 +91,22 @@ TESTS =
         id: ':id'
     reply: "Deploying app to staging: #{process.env.SHIPR_BASE}/deploys/:id"
 
+  'deploy app to staging':
+    beforeEach: (done) ->
+      @adapter.once 'reply', -> done()
+      @adapter.receive(new TextMessage(@user, "hubot foo is the default staging branch for app"))
+    request:
+      body:
+        repo: 'git@github.com:remind101/app.git'
+        branch: 'foo'
+        config:
+          ENVIRONMENT: 'staging'
+    response:
+      status: 201
+      body:
+        id: ':id'
+    reply: "Deploying app to staging: #{process.env.SHIPR_BASE}/deploys/:id"
+
 describe 'shipr', ->
 
   beforeEach (done) ->
@@ -104,6 +120,8 @@ describe 'shipr', ->
     for command, test of TESTS
       do (command, test) =>
         describe command, ->
+
+          beforeEach test.beforeEach if test.beforeEach
 
           beforeEach ->
             shipr

--- a/test/shipr_test.coffee
+++ b/test/shipr_test.coffee
@@ -99,20 +99,30 @@ describe 'shipr', ->
   afterEach ->
     nock.cleanAll()
 
-  for command, test of TESTS
-    do (command, test) =>
-      describe command, ->
+  describe 'deployment commands', ->
 
-        beforeEach ->
-          shipr
-            .post('/api/deploys', test.request.body, 'Authorization': 'Basic OmFwaWtleQ==')
-            .reply(test.response.status, test.response.body, { 'Content-Type': 'application/json' })
+    for command, test of TESTS
+      do (command, test) =>
+        describe command, ->
 
-        it 'responds appropriately', (done) ->
-          @adapter.on 'reply', (envelope, strings) ->
-            expect(strings[0]).to.eq(test.reply)
-            done()
-          @adapter.receive(new TextMessage(@user, "hubot #{command}"))
+          beforeEach ->
+            shipr
+              .post('/api/deploys', test.request.body, 'Authorization': 'Basic OmFwaWtleQ==')
+              .reply(test.response.status, test.response.body, { 'Content-Type': 'application/json' })
+
+          it 'responds appropriately', (done) ->
+            @adapter.on 'reply', (envelope, strings) ->
+              expect(strings[0]).to.eq(test.reply)
+              done()
+            @adapter.receive(new TextMessage(@user, "hubot #{command}"))
+
+  describe '<branch> is the <environment> branch for <name>', ->
+
+    it 'sets the branch for the app', (done) ->
+      @adapter.on 'reply', (envelope, strings) ->
+        expect(strings[0]).to.eq('foo')
+        done()
+      @adapter.receive(new TextMessage(@user, "hubot foo is the staging branch for r101-api"))
 
 # Run the robot.
 #

--- a/test/shipr_test.coffee
+++ b/test/shipr_test.coffee
@@ -120,9 +120,9 @@ describe 'shipr', ->
 
     it 'sets the branch for the app', (done) ->
       @adapter.on 'reply', (envelope, strings) ->
-        expect(strings[0]).to.eq('foo')
+        expect(strings[0]).to.eq('Ok, the default branch for r101-api when deployed to staging is foo')
         done()
-      @adapter.receive(new TextMessage(@user, "hubot foo is the staging branch for r101-api"))
+      @adapter.receive(new TextMessage(@user, "hubot foo is the default staging branch for r101-api"))
 
 # Run the robot.
 #


### PR DESCRIPTION
This adds a command for doing this:

```
hubot master is the default staging branch for r101-dashboard-beta
=> Ok, the default branch for r101-dashboard-beta when deployed to staging is master
```

So we don't always have to type r101-dashboard-beta#master
