### PR TITLE
Decouple from Shipr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,26 @@
-# Hubot Shipr
+# Hubot Deploy
 
-This is a [Hubot](https://github.com/github/hubot) script for [Shipr](https://github.com/remind101/shipr)
+This is a [Hubot](https://github.com/github/hubot) script for the [GitHub Deployments API](https://developer.github.com/v3/repos/deployments/).
 
 ## Install
 
-1. Add hubot-shipr to your package.json file:
+1. Add hubot-deploy to your package.json file:
 
    ```bash
-   $ npm install hubot-shipr --save
+   $ npm install hubot-deploy --save
    ```
 
-2. Add `hubot-shipr` to external-scripts.json:
+2. Add `hubot-deploy` to external-scripts.json:
 
    ```json
-   ["hubot-shipr"]
+   ["hubot-deploy"]
    ```
 
 3. Set the the following environment variables on your instance of hubot:
 
    ```
-   SHIPR_BASE=<base url for shipr>
-   SHIPR_AUTH=:<api key>
-   SHIPR_GITHUB_ORG=<your github organization>
+   GITHUB_TOKEN=:<api key>
+   GITHUB_ORG=<your github organization>
    ```
 
 ## Usage

--- a/lib/repo.coffee
+++ b/lib/repo.coffee
@@ -2,7 +2,7 @@ module.exports = (robot) ->
   BranchEnvironment = require('./branch_environment')(robot)
 
   class Repo
-    @organization: process.env.SHIPR_GITHUB_ORG
+    @organization: process.env.GITHUB_ORG
 
     constructor: (@name) ->
       @nwo = "#{@constructor.organization}/#{@name}"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "hubot-shipr",
+  "name": "hubot-deploy",
   "version": "1.1.0",
   "main": "index.coffee",
   "repository": {
     "type": "git",
-    "url": "https://github.com/remind101/hubot-shipr"
+    "url": "https://github.com/remind101/hubot-deploy"
   },
   "keywords": [
     "hubot",
-    "shipr"
+    "deploy"
   ],
   "author": "Eric Holmes",
   "license": "MIT",

--- a/scripts/deploy.coffee
+++ b/scripts/deploy.coffee
@@ -1,9 +1,9 @@
 # Description:
-#   Deploy apps with Hubot and Shipr.
+#   Deploy apps with Hubot and GitHub Deployments.
 #
 # Configuration:
-#   SHIPR_BASE
-#   SHIPR_GITHUB_ORG
+#   GITHUB_TOKEN
+#   GITHUB_ORG
 #
 # Commands:
 #   hubot deploy <app> - Fuck it! We'll do it live!

--- a/test/deploy_test.coffee
+++ b/test/deploy_test.coffee
@@ -1,26 +1,25 @@
 process.env.NODE_ENV = 'test'
-process.env.SHIPR_BASE = 'http://shipr.test'
-process.env.SHIPR_GITHUB_ORG = 'remind101'
-process.env.SHIPR_AUTH = ':apikey'
+process.env.GITHUB_ORG = 'remind101'
+process.env.GITHUB_TOKEN = '1234'
 
 {expect} = require 'chai'
-init     = require '../scripts/shipr'
+init     = require '../scripts/deploy'
 nock     = require 'nock'
 
 {Robot,TextMessage} = require('hubot')
 
-shipr = nock(process.env.SHIPR_BASE).log(console.log)
+api = nock('https://api.github.com').log(console.log)
 
 TESTS =
   'deploy app to production':
     request:
       body:
-        name: 'remind101/app'
         ref: 'master'
         environment: 'production'
+        auto_merge: false
+        required_contexts: null
         payload:
           user: 'eric'
-          force: false
     response:
       status: 201
       body:
@@ -29,12 +28,12 @@ TESTS =
   'deploy app':
     request:
       body:
-        name: 'remind101/app'
         ref: 'master'
         environment: 'production'
+        auto_merge: false
+        required_contexts: null
         payload:
           user: 'eric'
-          force: false
     response:
       status: 201
       body:
@@ -43,12 +42,12 @@ TESTS =
   'deploy app':
     request:
       body:
-        name: 'remind101/app'
         ref: 'master'
         environment: 'production'
+        auto_merge: false
+        required_contexts: null
         payload:
           user: 'eric'
-          force: false
     response:
       status: 422
       body:
@@ -58,12 +57,12 @@ TESTS =
   'deploy app to staging':
     request:
       body:
-        name: 'remind101/app'
         ref: 'develop'
         environment: 'staging'
+        auto_merge: false
+        required_contexts: null
         payload:
           user: 'eric'
-          force: false
     response:
       status: 201
       body:
@@ -72,12 +71,12 @@ TESTS =
   'deploy app#topic to staging':
     request:
       body:
-        name: 'remind101/app'
         ref: 'topic'
         environment: 'staging'
+        auto_merge: false
+        required_contexts: null
         payload:
           user: 'eric'
-          force: false
     response:
       status: 201
       body:
@@ -86,13 +85,12 @@ TESTS =
   'deploy app!':
     request:
       body:
-        name: 'remind101/app'
         ref: 'master'
         environment: 'production'
+        auto_merge: false
+        required_contexts: []
         payload:
           user: 'eric'
-          force: true
-        force: true
     response:
       status: 201
       body:
@@ -101,13 +99,12 @@ TESTS =
   'deploy app to staging!':
     request:
       body:
-        name: 'remind101/app'
         ref: 'develop'
         environment: 'staging'
+        auto_merge: false
+        required_contexts: []
         payload:
           user: 'eric'
-          force: true
-        force: true
     response:
       status: 201
       body:
@@ -119,18 +116,18 @@ TESTS =
       @adapter.receive(new TextMessage(@user, "hubot foo is the default staging branch for app"))
     request:
       body:
-        name: 'remind101/app'
         ref: 'foo'
         environment: 'staging'
+        auto_merge: false
+        required_contexts: null
         payload:
           user: 'eric'
-          force: false
     response:
       status: 201
       body:
         id: ':id'
 
-describe 'shipr', ->
+describe 'deploy', ->
 
   beforeEach (done) ->
     runRobot.call(this, done)
@@ -142,13 +139,13 @@ describe 'shipr', ->
 
     for command, test of TESTS
       do (command, test) =>
-        describe command, ->
+        describe '"' + command + '"', ->
 
           beforeEach test.beforeEach if test.beforeEach
 
           beforeEach ->
-            shipr
-              .post('/api/deploys', test.request.body, 'Authorization': 'Basic OmFwaWtleQ==')
+            api
+              .post('/repos/remind101/app/deployments', test.request.body, 'Authorization': 'Bearer 1234')
               .reply(test.response.status, test.response.body, { 'Content-Type': 'application/json' })
 
           it 'responds appropriately', (done) ->


### PR DESCRIPTION
Just some prep work for a new version of Shipr (which is being rebranded as Tugboat). This makes the plugin more generic and only talks to GitHub. The only reason it was talking to Shipr directly was to install the GitHub hook automatically, but I don't actually want to do that anymore to make it easier to phase in the new version (also faster feedback in chat since there's 2 less round trip http requests).
