### PR TITLE
Add `force` back in payload.

### DIFF
--- a/lib/deploy.coffee
+++ b/lib/deploy.coffee
@@ -42,6 +42,7 @@ module.exports = (robot) ->
         required_contexts: if @force then [] else null
         payload:
           user: @user
+          force: @force
 
       @_http("#{@constructor.base}/repos/#{@repo.nwo}/deployments")
         .post(JSON.stringify data) (err, res, body) ->

--- a/test/deploy_test.coffee
+++ b/test/deploy_test.coffee
@@ -20,6 +20,7 @@ TESTS =
         required_contexts: null
         payload:
           user: 'eric'
+          force: false
     response:
       status: 201
       body:
@@ -34,6 +35,7 @@ TESTS =
         required_contexts: null
         payload:
           user: 'eric'
+          force: false
     response:
       status: 201
       body:
@@ -48,6 +50,7 @@ TESTS =
         required_contexts: null
         payload:
           user: 'eric'
+          force: false
     response:
       status: 422
       body:
@@ -63,6 +66,7 @@ TESTS =
         required_contexts: null
         payload:
           user: 'eric'
+          force: false
     response:
       status: 201
       body:
@@ -77,6 +81,7 @@ TESTS =
         required_contexts: null
         payload:
           user: 'eric'
+          force: false
     response:
       status: 201
       body:
@@ -91,6 +96,7 @@ TESTS =
         required_contexts: []
         payload:
           user: 'eric'
+          force: true
     response:
       status: 201
       body:
@@ -105,6 +111,7 @@ TESTS =
         required_contexts: []
         payload:
           user: 'eric'
+          force: true
     response:
       status: 201
       body:
@@ -122,6 +129,7 @@ TESTS =
         required_contexts: null
         payload:
           user: 'eric'
+          force: false
     response:
       status: 201
       body:


### PR DESCRIPTION
Still need this for the time being since it gets used by the deploy script and heroku doesn't provider the `required_contexts` in the deployment status.
